### PR TITLE
Add support for custom labels on jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,128 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Java template
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+### Eclipse template
+
+.metadata
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+.recommenders
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# PyDev specific (Python IDE for Eclipse)
+*.pydevproject
+
+# CDT-specific (C/C++ Development Tooling)
+.cproject
+
+# Java annotation processor (APT)
+.factorypath
+
+# PDT-specific (PHP Development Tools)
+.buildpath
+
+# sbteclipse plugin
+.target
+
+# Tern plugin
+.tern-project
+
+# TeXlipse plugin
+.texlipse
+
+# STS (Spring Tool Suite)
+.springBeans
+
+# Code Recommenders
+.recommenders/
+
+# Scala IDE specific (Scala & Java development for Eclipse)
+.cache-main
+.scala_dependencies
+.worksheet
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/dictionaries
+
+# Sensitive or high-churn files:
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.xml
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+
+# Gradle:
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# CMake
+cmake-build-debug/
+
+# Mongo Explorer plugin:
+.idea/**/mongoSettings.xml
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+.idea
+*.iml

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,7 @@ repositories {
 
 dependencies {
     compile group: 'org.rundeck', name: 'rundeck-core', version: '2.9.3'
+    testCompile group: 'junit', name: 'junit', version: '4.12'
     pluginLibs group: 'io.fabric8', name: 'kubernetes-client', version: '2.6.3'
 }
 

--- a/src/main/java/com/skilld/kubernetes/JobBuilder.java
+++ b/src/main/java/com/skilld/kubernetes/JobBuilder.java
@@ -22,12 +22,10 @@
 
 package com.skilld.kubernetes;
 
-import com.skilld.kubernetes.JobConfiguration;
-
-import io.fabric8.kubernetes.api.model.Job;
 import io.fabric8.kubernetes.api.model.Container;
-import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.kubernetes.api.model.Job;
 import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
+import io.fabric8.kubernetes.api.model.VolumeMount;
 
 import java.util.List;
 import java.util.Map;
@@ -40,15 +38,12 @@ public class JobBuilder {
 				.withNamespace(configuration.getNamespace())
 			.endMetadata()
 			.withNewSpec()
-				.withNewSelector()
-				.withMatchLabels(configuration.getLabels())
-				.endSelector()
 				.withParallelism(configuration.getParallelism())
 				.withCompletions(configuration.getCompletions())
 				.withNewTemplate()
-					.withNewMetadata()
-						.withLabels(configuration.getLabels())
-					.endMetadata()
+                    .withNewMetadata()
+                        .withLabels(configuration.getLabels())
+                    .endMetadata()
 					.withNewSpec()
 						.withRestartPolicy(configuration.getRestartPolicy())
 						.addNewContainer()

--- a/src/main/java/com/skilld/rundeck/plugin/step/kubernetes/KubernetesStep.java
+++ b/src/main/java/com/skilld/rundeck/plugin/step/kubernetes/KubernetesStep.java
@@ -125,7 +125,7 @@ public class KubernetesStep implements StepPlugin, Describable {
 		.property(PropertyUtil.string(SECRET, "Secret", "The name of the kubernetes secret in format <name>;<mountpath>", false, null))
 		.property(PropertyUtil.string(RESOURCE_REQUESTS, "Resource Requests", "Request resources in format cpu:4 memory:24Gi", false, null))
         .property(PropertyUtil.string(LABELS, "Labels", "The labels to set on the jobs. Labels are separated by '" + LABELSEPARATOR + "', keys and values by a '" + LABELKVSEPARATOR + "'. "
-				+ "Example: 'foo" + LABELKVSEPARATOR + "bar" + LABELKVSEPARATOR + "a" + LABELSEPARATOR + "b'. See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set for "
+				+ "Example: 'foo" + LABELKVSEPARATOR + "bar" + LABELSEPARATOR + "a" + LABELKVSEPARATOR + "b'. See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set for "
 				+ "information on key and value formatting.",false, ""))
 		.property(PropertyUtil.bool(CLEAN_UP, "Cleanup", "Remove finished jobs from Kubernetes", true, "true"))
 		.build();

--- a/src/test/java/com/skilld/rundeck/plugin/step/kubernetes/KubernetesStepTest.java
+++ b/src/test/java/com/skilld/rundeck/plugin/step/kubernetes/KubernetesStepTest.java
@@ -1,0 +1,80 @@
+package com.skilld.rundeck.plugin.step.kubernetes;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.*;
+
+public class KubernetesStepTest {
+
+    private static final String SEPARATOR = "=";
+    @Test
+    public void validateLabel() {
+        // make sure both separator and keyValue cannot be null or empty
+        assertFalse(KubernetesStep.validateLabel(null, "foo=bar"));
+        assertFalse(KubernetesStep.validateLabel("", "foo=bar"));
+        assertFalse(KubernetesStep.validateLabel(SEPARATOR, null));
+        assertFalse(KubernetesStep.validateLabel(SEPARATOR, ""));
+
+        // test some valid cases
+        Arrays.asList(
+                "kubernetes.io/foo=bar",
+                "k.uber.netes.io/F_o-0=b.a-r",
+                "foo=bar",
+                "a="
+        ).stream()
+                .forEach(label -> assertTrue(KubernetesStep.validateLabel(SEPARATOR, label)));
+
+        // test some invalid cases
+        Arrays.asList(
+                "=a",
+                "/foo=bar",
+                "foo/=bar",
+                "kubernetes-io/foo=bar",
+                "kubernetes io/foo=bar",
+                "kubernetes.io/foo=b ar",
+                "_foo=bar",
+                "-foo=bar",
+                ".foo=bar",
+                "foo=bar_",
+                "foo=bar-",
+                "foo=bar."
+        ).stream()
+                .forEach(label -> assertFalse(KubernetesStep.validateLabel(SEPARATOR, label)));
+
+        // components of labels are only allowed a certain length
+
+        // create a string of 253 a's, which is the maximum length prefix allowed in the key
+        final String maxLengthPrefix = IntStream.range(0, 253)
+                .mapToObj((i) -> "a")
+                .collect(Collectors.joining());
+        // test if it validates
+        assertTrue(KubernetesStep.validateLabel(SEPARATOR, maxLengthPrefix + "/foo=bar"));
+        // make the prefix one character longer, it shouldn't validate
+        assertFalse(KubernetesStep.validateLabel(SEPARATOR, maxLengthPrefix + "a/foo=bar"));
+
+        // the name part of the key can be at most 63 characters long
+        final String maxLengthName = IntStream.range(0, 63)
+                .mapToObj((i) -> "b")
+                .collect(Collectors.joining());
+        // test if it validates
+        assertTrue(KubernetesStep.validateLabel(SEPARATOR, maxLengthPrefix + "/" + maxLengthName + "=bar"));
+        // make the name of the key one character too long
+        assertFalse(KubernetesStep.validateLabel(SEPARATOR, maxLengthPrefix + "/b" + maxLengthName + "=bar"));
+
+        // the value can be at most 63 characters long, like the name of the key
+        final String maxLengthVal = IntStream.range(0, 63)
+                .mapToObj((i) -> "c")
+                .collect(Collectors.joining());
+        // test if it validates
+        assertTrue(KubernetesStep.validateLabel(SEPARATOR,
+                maxLengthPrefix + "/" + maxLengthName + SEPARATOR + maxLengthVal));
+        // make the val one character too long
+        assertFalse(KubernetesStep.validateLabel(SEPARATOR,
+                maxLengthPrefix + "/" + maxLengthName + "=c" + maxLengthVal));
+    }
+}


### PR DESCRIPTION
This PR adds support for custom labels on jobs. Note that for some reason the configured labels were used as label selectors as well (https://github.com/boyvanduuren/rundeck-kubernetes-step-plugin/commit/964903da1856bb64f9052a0df025f51e1763a7ef) which lead to an error while creating the job. I've removed the creation of selector labels which means k8s itself will generate one.
We've tested these changed and didn't ran into any issues.

I've also added tests for the label validator.